### PR TITLE
Rewrite split algorithm and allow returning everything without pinyin list wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,12 @@ console.log(split('本：wo de mao xihuan he niunai！'))
 // ['wo', 'de', 'mao', 'xi', 'huan', 'he', 'niu', 'nai']
 
 // return everything and wrap pinyin into lists
-console.log(split('本：ni jiao shenme mingzi？', true))
+console.log(split('本：ni jiao shenme mingzi？', true, true))
 // ['本：'['ni'], ' ', ['jiao'], ' ', ['shen'], ['me'], ' ', ['ming'], ['zi'], '？']
+
+// return everything and don't wrap pinyin into lists
+console.log(split('Nǐ huì shuō Yīngwén ma?', true))
+// ['Nǐ', ' ', 'huì', ' ', 'shuō', ' ', 'Yīng', 'wén', ' ', 'ma', '?']
 ```
 
 ## Related

--- a/index.js
+++ b/index.js
@@ -6,8 +6,9 @@ const allWords = Object.values(wordsData).reduce((o, i) => o.concat(i), [])
 
 const normalizePinyin = (pinyin) => pinyin.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/(\w)[1-5]/g, '$1').toLowerCase()
 
-const split = (text, everything=false, returnAsList=false) => {
+const split = (text, everything=false, wrapInList=false) => {
   const list = []
+  let prevWordFound = false
   let wordEnd = text.length
   while (wordEnd > 0) {
     let count = wordEnd
@@ -16,26 +17,24 @@ const split = (text, everything=false, returnAsList=false) => {
       const word = text.substring(wordEnd - count, wordEnd)
       if (allWords.includes(normalizePinyin(word))) {
         wordFound = true
-        list.push(returnAsList ? [word] : word)
+        list.push(wrapInList ? [word] : word)
         wordEnd -= (count - 1)
         break
       }
       count--
     }
     if (!wordFound && everything) {
-      if (wordEnd === text.length || typeof list[list.length - 1] === 'object' || !returnAsList) {
+      const prevIndex = list.length - 1
+      const prevEntry = list[prevIndex]
+      if (wordEnd === text.length || typeof prevEntry === 'object' || prevWordFound) {
         list.push(text[wordEnd - 1])
       }
-      else if (typeof list[list.length - 1] === 'string') {
-        if (returnAsList) {
-          list[list.length - 1] = text[wordEnd - 1] + list[list.length - 1]
-        } else {
-          list[list.length - 1] = list[list.length - 1]
-          list.splice(list.length - 1, 0, text[wordEnd - 1])
-        }
+      else if (typeof prevEntry === 'string') {
+        list[prevIndex] = text[wordEnd - 1] + prevEntry
       }
     }
     wordEnd --
+    prevWordFound = wordFound
   }
   return list.reverse()
 }

--- a/index.js
+++ b/index.js
@@ -1,45 +1,42 @@
 'use strict'
 
-const utils = require('pinyin-utils')
 const wordsData = require('./words.json')
 
-let allWords = Object.values(wordsData).reduce((o, i) => o.concat(i), [])
+const allWords = Object.values(wordsData).reduce((o, i) => o.concat(i), [])
 
-const wordsCount = allWords.length
-for (let i = 0; i < wordsCount; i++) {
-  for (let n = 1; n <= 5; n++) {
-    allWords.push(utils.numberToMark(allWords[i] + n))
-    allWords.push(allWords[i] + n)
-  }
-}
+const normalizePinyin = (pinyin) => pinyin.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/(\w)[1-5]/g, '$1').toLowerCase()
 
-const split = (text, everything) => {
-  const list = []
-  let wordEnd = text.length
-  while (wordEnd > 0) {
-    let count = wordEnd
-    let wordFound = false
-    while (count > 0) {
-      const word = text.substring(wordEnd - count, wordEnd)
-      if (allWords.includes(word.toLowerCase())) {
-        wordFound = true
-        list.push(everything ? [word] : word)
-        wordEnd -= (count - 1)
-        break
-      }
-      count--
+const split = (text, everything=false, list=false) => {
+    const words = []
+    let previousString = ''
+    let currentString = ''
+    for (const [i,char] of text.split('').reverse().entries()) {
+        currentString = char + currentString
+        const previousStringNormalized = normalizePinyin(previousString)
+        const currentStringNormalized = normalizePinyin(currentString)
+        const isLastIteration = i+1===text.length
+        const isFirstAndNotLastIteration = text.length>1 && i===0
+        const currentContainsOnlySpecialChars = /^[^\w]+$/.test(currentStringNormalized)
+        const previousContainsOnlySpecialChars = /^[^\w]+$/.test(previousStringNormalized)
+        const currentIsValidWord = allWords.includes(currentStringNormalized)
+        const previousIsValidWord = allWords.includes(previousStringNormalized)
+        const currentMatchCount = allWords.filter(word=>word.includes(currentStringNormalized)).length
+        const previousMatchCount = allWords.filter(word=>word.includes(previousStringNormalized)).length
+        if (!isFirstAndNotLastIteration && ((previousMatchCount >= 1 && currentMatchCount === 0) || isLastIteration || (previousContainsOnlySpecialChars && !currentContainsOnlySpecialChars))) {
+            if (everything || currentIsValidWord || previousIsValidWord) {
+                if (currentIsValidWord || currentContainsOnlySpecialChars) {
+                    words.push(list && currentIsValidWord ? [currentString] : currentString)
+                } else {
+                    words.push(list && previousIsValidWord ? [previousString] : previousString)
+                    if (isFirstAndNotLastIteration)
+                        words.push(char)
+                }
+            }
+            currentString = char
+        }
+        previousString = currentString
     }
-    if (!wordFound && everything) {
-      if (wordEnd === text.length || typeof list[list.length - 1] === 'object') {
-        list.push(text[wordEnd - 1])
-      }
-      else if (typeof list[list.length - 1] === 'string') {
-        list[list.length - 1] = text[wordEnd - 1] + list[list.length - 1]
-      }
-    }
-    wordEnd --
-  }
-  return list.reverse()
+    return words.reverse()
 }
 
 module.exports = split

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
       "dev": true
     },
     "commander": {
-      "version": "2.11.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.11.0.tgz",
-      "integrity": "sha512-b0553uYA5YAEGgyYIGYROzKQ7X5RAqedkfjiZxwi0kL1g3bOaBNNZfYkzt/CL0umgD5wc9Jec2FbB98CjkMRvQ==",
+      "version": "2.15.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
+      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
       "dev": true
     },
     "concat-map": {
@@ -80,15 +80,15 @@
       }
     },
     "growl": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.3.tgz",
-      "integrity": "sha512-hKlsbA5Vu3xsh1Cg3J7jSmX/WaW6A5oBeqzM88oNbCRQFz+zUaXm6yxS4RVytp1scBoJzSYl4YAEOQIt6O8V1Q==",
+      "version": "1.10.5",
+      "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "has-flag": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-      "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
       "dev": true
     },
     "he": {
@@ -138,22 +138,22 @@
       }
     },
     "mocha": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.1.1.tgz",
-      "integrity": "sha512-kKKs/H1KrMMQIEsWNxGmb4/BGsmj0dkeyotEvbrAuQ01FcWRLssUNXCEUZk6SZtyJBi6EE7SL0zDDtItw1rGhw==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-5.2.0.tgz",
+      "integrity": "sha512-2IUgKDhc3J7Uug+FxMXuqIyYzH7gJjXECKe/w43IGgQHTSj3InJi+yAA7T24L9bQMRKiUEHxEX37G5JpVUGLcQ==",
       "dev": true,
       "requires": {
         "browser-stdout": "1.3.1",
-        "commander": "2.11.0",
+        "commander": "2.15.1",
         "debug": "3.1.0",
         "diff": "3.5.0",
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.2",
-        "growl": "1.10.3",
+        "growl": "1.10.5",
         "he": "1.1.1",
         "minimatch": "3.0.4",
         "mkdirp": "0.5.1",
-        "supports-color": "4.4.0"
+        "supports-color": "5.4.0"
       }
     },
     "ms": {
@@ -177,18 +177,10 @@
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
-    "pinyin-utils": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/pinyin-utils/-/pinyin-utils-1.0.8.tgz",
-      "integrity": "sha512-mwt/urJFgmGQC0CeAYE05XCiFR7ruihlrhWu2D5lcsmYn/YFe469v1Y9Cl3ksL2vQZZRbqYgrxz+qts2ses2oQ==",
-      "requires": {
-        "trim": "0.0.1"
-      }
-    },
     "should": {
-      "version": "13.2.1",
-      "resolved": "https://registry.npmjs.org/should/-/should-13.2.1.tgz",
-      "integrity": "sha512-l+/NwEMO+DcstsHEwPHRHzC9j4UOE3VQwJGcMWSsD/vqpqHbnQ+1iSHy64Ihmmjx1uiRPD9pFadTSc3MJtXAgw==",
+      "version": "13.2.3",
+      "resolved": "https://registry.npmjs.org/should/-/should-13.2.3.tgz",
+      "integrity": "sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==",
       "dev": true,
       "requires": {
         "should-equal": "^2.0.0",
@@ -240,18 +232,13 @@
       "dev": true
     },
     "supports-color": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.4.0.tgz",
-      "integrity": "sha512-rKC3+DyXWgK0ZLKwmRsrkyHVZAjNkfzeehuFWdGGcqGDTZFH73+RH6S/RDAAxl9GusSjZSUWYLmT9N5pzXFOXQ==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
+      "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "dev": true,
       "requires": {
-        "has-flag": "^2.0.0"
+        "has-flag": "^3.0.0"
       }
-    },
-    "trim": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/trim/-/trim-0.0.1.tgz",
-      "integrity": "sha1-WFhUf2spB1fulczMZm+1AITEYN0="
     },
     "wrappy": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -22,9 +22,6 @@
   "scripts": {
     "test": "mocha"
   },
-  "dependencies": {
-    "pinyin-utils": "^1.0.8"
-  },
   "devDependencies": {
     "mocha": "^5.0.1",
     "should": "^13.2.1"

--- a/test/index.js
+++ b/test/index.js
@@ -73,13 +73,24 @@ describe('Split spaced text and keep spaces', () => {
 
 describe('Split spaced and punctuated text and keep spaces as well as punctuation', () => {
 	it('should split the text into the correct words and punctuation', done => {
-		const list = ['Wô',' ','bú',' ','huì',' ','shuō',' ','Yīng','wén','.']
-		split('Wô bú huì shuō Yīngwén.', true).should.deepEqual(list)
+		const list = ['Wǒ',' ','bú',' ','huì',' ','shuō',' ','Yīng','wén','.']
+		split('Wǒ bú huì shuō Yīngwén.', true).should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words and punctuation', done => {
 		const list = ['Wo3',' ','bu2',' ','hui4',' ','shuo1',' ','Ying1','wen2','.']
 		split('Wo3 bu2 hui4 shuo1 Ying1wen2.', true).should.deepEqual(list)
+		done()
+	})
+})
+
+describe('Split text containing English words', () => {
+	it('should split text containing English and Pinyin correctly', done => {
+		const list = [
+            'This is ', [ 'ran' ], 'd', [ 'o' ], 'm ', [ 'te' ], 'xt: "',
+            [ 'wo' ], [ 'de' ], [ 'mao' ], [ 'xi' ], [ 'huan' ], [ 'he' ], [ 'niu' ], [ 'nai' ], '".'
+        ]
+		split('This is random text: "wodemaoxihuanheniunai".', true, true).should.deepEqual(list)
 		done()
 	})
 })

--- a/test/index.js
+++ b/test/index.js
@@ -56,17 +56,30 @@ describe('Split text and return Pinyin only', () => {
 describe('Split spaced text and keep spaces', () => {
 	it('should split the text into the correct words', done => {
 		const list = [['wo'], ' ', ['de'], ' ', ['mao'], ' ', ['xi'], ['huan'], ' ', ['he'], ' ', ['niu'], ['nai']]
-		split('wo de mao xihuan he niunai', true).should.deepEqual(list)
+		split('wo de mao xihuan he niunai', true, true).should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words', done => {
 		const list = [['wo3'], ' ', ['de'], ' ', ['mao1'], ' ', ['xi3'], ['huan'], ' ', ['he2'], ' ', ['niu3'], ['nai3']]
-		split('wo3 de mao1 xi3huan he2 niu3nai3', true).should.deepEqual(list)
+		split('wo3 de mao1 xi3huan he2 niu3nai3', true, true).should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words', done => {
 		const list = [['wǒ'], ' ', ['de'], ' ', ['māo'], ' ', ['xǐ'], ['huan'], ' ', ['hé'], ' ', ['niǔ'], ['nǎi']]
-		split('wǒ de māo xǐhuan hé niǔnǎi', true).should.deepEqual(list)
+		split('wǒ de māo xǐhuan hé niǔnǎi', true, true).should.deepEqual(list)
+		done()
+	})
+})
+
+describe('Split spaced and punctuated text and keep spaces as well as punctuation', () => {
+	it('should split the text into the correct words and punctuation', done => {
+		const list = ['Wô',' ','bú',' ','huì',' ','shuō',' ','Yīng','wén','.']
+		split('Wô bú huì shuō Yīngwén.', true).should.deepEqual(list)
+		done()
+	})
+	it('should split the text into the correct words and punctuation', done => {
+		const list = ['Wo3',' ','bu2',' ','hui4',' ','shuo1',' ','Ying1','wen2','.']
+		split('Wo3 bu2 hui4 shuo1 Ying1wen2.', true).should.deepEqual(list)
 		done()
 	})
 })

--- a/test/index.js
+++ b/test/index.js
@@ -2,95 +2,167 @@
 
 const split = require('../index')
 
-describe('Split text and keep non-pinyin text', () => {
+// Test case for split(string, false, false)
+
+describe('Split text with non-spaced Pinyin and return Pinyin only', () => {
 	it('should split the text into the correct words', done => {
-		const list = ['wo', 'de', 'mao', 'xi', 'huan', 'he', 'niu', 'nai']
-		split('wodemaoxihuanheniunai').should.deepEqual(list)
+		const list = ['a', 'an', 'Pin', 'yin', 'wo', 'de', 'mao', 'xi', 'huan', 'he', 'niu', 'nai']
+		split('I am 本 and this is Pinyin: "wodemaoxihuanheniunai".').should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words', done => {
-		const list = ['wo3', 'de', 'mao1', 'xi3', 'huan1', 'he2', 'niu3', 'nai3']
-		split('wo3demao1xi3huan1he2niu3nai3').should.deepEqual(list)
+		const list = ['a', 'an', 'Pin', 'yin', 'wo3', 'de', 'mao1', 'xi3', 'huan', 'he1', 'niu2', 'nai3']
+		split('I am 本 and this is Pinyin: "wo3demao1xi3huanhe1niu2nai3".').should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words', done => {
-		const list = ['wǒ', 'de', 'māo', 'xǐ', 'huān', 'hé', 'niǔ', 'nǎi']
-		split('wǒdemāoxǐhuānhéniǔnǎi').should.deepEqual(list)
-		done()
-	})
-	it('should split the text into the correct words', done => {
-		const list = ['de', 're', 'wo', 'fen', 'dou', 'dou', 'wo', 'ren', 'wei']
-		split('derewofendoudouworenwei').should.deepEqual(list)
-		done()
-	})
-	it('should split the text into the correct words', done => {
-		const list = ['de2', 're3', 'wo3', 'fen4', 'dou4', 'dou3', 'wo3', 'ren4', 'wei4']
-		split('de2re3wo3fen4dou4dou3wo3ren4wei4').should.deepEqual(list)
-		done()
-	})
-	it('should split the text into the correct words', done => {
-		const list = ['dé', 'rě', 'wǒ', 'fèn', 'dòu', 'dǒu', 'wǒ', 'rèn', 'wèi']
-		split('dérěwǒfèndòudǒuwǒrènwèi').should.deepEqual(list)
+		const list = ['a', 'an', 'Pin', 'yin', 'wǒ', 'de', 'māo', 'xǐ', 'huan', 'hē', 'niú', 'nǎi']
+		split('I am 本 and this is Pinyin: "wǒdemāoxǐhuanhēniúnǎi".').should.deepEqual(list)
 		done()
 	})
 })
 
-describe('Split text and return Pinyin only', () => {
+describe('Split text with spaced Pinyin and return Pinyin only', () => {
 	it('should split the text into the correct words', done => {
-		const list = ['wo', 'de', 'mao', 'xi', 'huan', 'he', 'niu', 'nai']
-		split('wo de mao xihuan he niunai').should.deepEqual(list)
+		const list = ['a', 'an', 'Pin', 'yin', 'wo', 'de', 'mao', 'xi', 'huan', 'he', 'niu', 'nai']
+		split('I am 本 and this is Pinyin: "wo de mao xihuan he niunai".').should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words', done => {
-		const list = ['wo3', 'de', 'mao1', 'xi3', 'huan1', 'he2', 'niu3', 'nai3']
-		split('wo3 de mao1 xi3huan1 he2 niu3nai3').should.deepEqual(list)
+		const list = ['a', 'an', 'Pin', 'yin', 'wo3', 'de', 'mao1', 'xi3', 'huan', 'he1', 'niu2', 'nai3']
+		split('I am 本 and this is Pinyin: "wo3 de mao1 xi3huan he1 niu2nai3".').should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words', done => {
-		const list = ['wǒ', 'de', 'māo', 'xǐ', 'huān', 'hé', 'niǔ', 'nǎi']
-		split('wǒ de māo xǐhuān hé niǔnǎi').should.deepEqual(list)
+		const list = ['a', 'an', 'Pin', 'yin', 'wǒ', 'de', 'māo', 'xǐ', 'huan', 'hē', 'niú', 'nǎi']
+		split('I am 本 and this is Pinyin: "wǒ de māo xǐhuan hē niúnǎi".').should.deepEqual(list)
 		done()
 	})
 })
 
-describe('Split spaced text and keep spaces', () => {
+// Test case for split(string, true, false)
+
+describe('Split text with non-spaced Pinyin and return everything', () => {
 	it('should split the text into the correct words', done => {
-		const list = [['wo'], ' ', ['de'], ' ', ['mao'], ' ', ['xi'], ['huan'], ' ', ['he'], ' ', ['niu'], ['nai']]
-		split('wo de mao xihuan he niunai', true, true).should.deepEqual(list)
+		const list = [
+			'I ', 'a', 'm 本 ', 'an', 'd this is ', 'Pin', 'yin', ': "',
+			'wo', 'de', 'mao', 'xi', 'huan', 'he', 'niu', 'nai', '".'
+		]
+		split('I am 本 and this is Pinyin: "wodemaoxihuanheniunai".', true).should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words', done => {
-		const list = [['wo3'], ' ', ['de'], ' ', ['mao1'], ' ', ['xi3'], ['huan'], ' ', ['he2'], ' ', ['niu3'], ['nai3']]
-		split('wo3 de mao1 xi3huan he2 niu3nai3', true, true).should.deepEqual(list)
+		const list = [
+			'I ', 'a', 'm 本 ', 'an', 'd this is ', 'Pin', 'yin', ': "',
+			'wo3', 'de', 'mao1', 'xi3', 'huan', 'he1', 'niu2', 'nai3', '".'
+		]
+		split('I am 本 and this is Pinyin: "wo3demao1xi3huanhe1niu2nai3".', true).should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words', done => {
-		const list = [['wǒ'], ' ', ['de'], ' ', ['māo'], ' ', ['xǐ'], ['huan'], ' ', ['hé'], ' ', ['niǔ'], ['nǎi']]
-		split('wǒ de māo xǐhuan hé niǔnǎi', true, true).should.deepEqual(list)
+		const list = [
+			'I ', 'a', 'm 本 ', 'an', 'd this is ', 'Pin', 'yin', ': "',
+			'wǒ', 'de', 'māo', 'xǐ', 'huan', 'hē', 'niú', 'nǎi', '".'
+		]
+		split('I am 本 and this is Pinyin: "wǒdemāoxǐhuanhēniúnǎi".', true).should.deepEqual(list)
 		done()
 	})
 })
+
+describe('Split text with spaced Pinyin and return everything', () => {
+	it('should split the text into the correct words', done => {
+		const list = [
+			'I ', 'a', 'm 本 ', 'an', 'd this is ', 'Pin', 'yin', ': "',
+			'wo', ' ', 'de', ' ', 'mao', ' ', 'xi', 'huan', ' ', 'he', ' ', 'niu', 'nai', '".'
+		]
+		split('I am 本 and this is Pinyin: "wo de mao xihuan he niunai".', true).should.deepEqual(list)
+		done()
+	})
+	it('should split the text into the correct words', done => {
+		const list = [
+			'I ', 'a', 'm 本 ', 'an', 'd this is ', 'Pin', 'yin', ': "',
+			'wo3', ' ', 'de', ' ', 'mao1', ' ', 'xi3', 'huan', ' ', 'he1', ' ', 'niu2', 'nai3', '".'
+		]
+		split('I am 本 and this is Pinyin: "wo3 de mao1 xi3huan he1 niu2nai3".', true).should.deepEqual(list)
+		done()
+	})
+	it('should split the text into the correct words', done => {
+		const list = [
+			'I ', 'a', 'm 本 ', 'an', 'd this is ', 'Pin', 'yin', ': "',
+			'wǒ', ' ', 'de', ' ', 'māo', ' ', 'xǐ', 'huan', ' ', 'hē', ' ', 'niú', 'nǎi', '".'
+		]
+		split('I am 本 and this is Pinyin: "wǒ de māo xǐhuan hē niúnǎi".', true).should.deepEqual(list)
+		done()
+	})
+})
+
+// Test case for split(string, true, true)
+
+describe('Split text with non-spaced Pinyin and return everything with Pinyin wrapped in lists', () => {
+	it('should split the text into the correct words', done => {
+		const list = [
+			'I ', ['a'], 'm 本 ', ['an'], 'd this is ', ['Pin'], ['yin'], ': "',
+			['wo'], ['de'], ['mao'], ['xi'], ['huan'], ['he'], ['niu'], ['nai'], '".'
+		]
+		split('I am 本 and this is Pinyin: "wodemaoxihuanheniunai".', true, true).should.deepEqual(list)
+		done()
+	})
+	it('should split the text into the correct words', done => {
+		const list = [
+			'I ', ['a'], 'm 本 ', ['an'], 'd this is ', ['Pin'], ['yin'], ': "',
+			['wo3'], ['de'], ['mao1'], ['xi3'], ['huan'], ['he1'], ['niu2'], ['nai3'], '".'
+		]
+		split('I am 本 and this is Pinyin: "wo3demao1xi3huanhe1niu2nai3".', true, true).should.deepEqual(list)
+		done()
+	})
+	it('should split the text into the correct words', done => {
+		const list = [
+			'I ', ['a'], 'm 本 ', ['an'], 'd this is ', ['Pin'], ['yin'], ': "',
+			['wǒ'], ['de'], ['māo'], ['xǐ'], ['huan'], ['hē'], ['niú'], ['nǎi'], '".'
+		]
+		split('I am 本 and this is Pinyin: "wǒdemāoxǐhuanhēniúnǎi".', true, true).should.deepEqual(list)
+		done()
+	})
+})
+
+describe('Split text with spaced Pinyin and return everything with Pinyin wrapped in lists', () => {
+	it('should split the text into the correct words', done => {
+		const list = [
+			'I ', ['a'], 'm 本 ', ['an'], 'd this is ', ['Pin'], ['yin'], ': "',
+			['wo'], ' ', ['de'], ' ', ['mao'], ' ', ['xi'], ['huan'], ' ', ['he'], ' ', ['niu'], ['nai'], '".'
+		]
+		split('I am 本 and this is Pinyin: "wo de mao xihuan he niunai".', true, true).should.deepEqual(list)
+		done()
+	})
+	it('should split the text into the correct words', done => {
+		const list = [
+			'I ', ['a'], 'm 本 ', ['an'], 'd this is ', ['Pin'], ['yin'], ': "',
+			['wo3'], ' ', ['de'], ' ', ['mao1'], ' ', ['xi3'], ['huan'], ' ', ['he1'], ' ', ['niu2'], ['nai3'], '".'
+		]
+		split('I am 本 and this is Pinyin: "wo3 de mao1 xi3huan he1 niu2nai3".', true, true).should.deepEqual(list)
+		done()
+	})
+	it('should split the text into the correct words', done => {
+		const list = [
+			'I ', ['a'], 'm 本 ', ['an'], 'd this is ', ['Pin'], ['yin'], ': "',
+			['wǒ'], ' ', ['de'], ' ', ['māo'], ' ', ['xǐ'], ['huan'], ' ', ['hē'], ' ', ['niú'], ['nǎi'], '".'
+		]
+		split('I am 本 and this is Pinyin: "wǒ de māo xǐhuan hē niúnǎi".', true, true).should.deepEqual(list)
+		done()
+	})
+})
+
+// Extra test case
 
 describe('Split spaced and punctuated text and keep spaces as well as punctuation', () => {
 	it('should split the text into the correct words and punctuation', done => {
-		const list = ['Wǒ',' ','bú',' ','huì',' ','shuō',' ','Yīng','wén','.']
+		const list = ['Wǒ', ' ', 'bú', ' ', 'huì', ' ', 'shuō', ' ', 'Yīng', 'wén', '.']
 		split('Wǒ bú huì shuō Yīngwén.', true).should.deepEqual(list)
 		done()
 	})
 	it('should split the text into the correct words and punctuation', done => {
-		const list = ['Wo3',' ','bu2',' ','hui4',' ','shuo1',' ','Ying1','wen2','.']
+		const list = ['Wo3', ' ', 'bu2', ' ', 'hui4', ' ', 'shuo1', ' ', 'Ying1', 'wen2', '.']
 		split('Wo3 bu2 hui4 shuo1 Ying1wen2.', true).should.deepEqual(list)
-		done()
-	})
-})
-
-describe('Split text containing English words', () => {
-	it('should split text containing English and Pinyin correctly', done => {
-		const list = [
-            'This is ', [ 'ran' ], 'd', [ 'o' ], 'm ', [ 'te' ], 'xt: "',
-            [ 'wo' ], [ 'de' ], [ 'mao' ], [ 'xi' ], [ 'huan' ], [ 'he' ], [ 'niu' ], [ 'nai' ], '".'
-        ]
-		split('This is random text: "wodemaoxihuanheniunai".', true, true).should.deepEqual(list)
 		done()
 	})
 })


### PR DESCRIPTION
I forked your project because I needed a way to split the pinyin in a certain way. Your project almost did it for me, but not quite, I had to make some modifications. I was just looking for a way to convert the original text input into an array of pinyin syllables and special characters (punctuation etc). 
I ended up completely rewriting your split algorithm because I figured the pinyin-utils aren't really necessary. I am declaring a lot of variables with meaningful names in the algorithm so that it becomes easier to understand.

the split function now has 3 parameters instead of two. The first one is for the text input (as before) the second one is to tell if you want to return everything (or just the pinyin) and the third one is to specify if the pinyin should be wrapped in arrays. So basically instead of `sort('ni hao ma?',true)` you now have to do `sort('ni hao ma?',true,true)` instead now. This, unfortunately,  is a "breaking change" if you will, but it made the most sense to me tbh and my intention wasn't really to make a PR. But I figured I would just create one and let you decide if you like it or not.

Offtopic:
I really like your projects btw! I've used quite a few of them recently. I wish I would have found them earlier though. It would have saved me quite some time. ;)  
I will use pinyin-split in this project btw: https://github.com/FOSS-Chinese/AnkiDeckGenerator
There is some cool stuff in the project that might be interesting to you, if you're learning Chinese.